### PR TITLE
Fix Prettier check in DEPLOYMENT.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -111,7 +111,7 @@ The actual steps performed by the deploy workflow are:
 
 ```yaml
 env:
-   NEXT_PUBLIC_BASE_PATH: /FFC-EX-nittanypost245.org
+  NEXT_PUBLIC_BASE_PATH: /FFC-EX-nittanypost245.org
 ```
 
 This ensures images and assets work correctly at the GitHub Pages subpath.


### PR DESCRIPTION
Fixes a small indentation issue in DEPLOYMENT.md that was causing the CI 'format:check' step to fail.