### PR TITLE
fix: correct Auxiliary meeting time to 1900 on home page Events

### DIFF
--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -74,7 +74,7 @@ const Events = () => {
                 the month
               </p>
               <p className="text-[16px] font-[400]" id="lato-font">
-                <strong>American Legion Auxiliary Meeting:</strong> 1800 on the 4th Tuesday of the
+                <strong>American Legion Auxiliary Meeting:</strong> 1900 on the 4th Tuesday of the
                 month
               </p>
               <p className="text-[16px] font-[400]" id="lato-font">


### PR DESCRIPTION
## Summary

The American Legion Auxiliary (Unit 245) meeting time was displayed as **1800 (6:00 PM)** in the home page Events section, but the correct time is **1900 (7:00 PM)** on the 4th Tuesday of the month. This changes `1800` → `1900` (the 4th-Tuesday day is unchanged).

Fixes #117

## Changes

- `src/components/home-page/Events/index.tsx` — Auxiliary meeting time `1800` → `1900`.

## Verification

- Repo-wide search confirmed no other page (meeting-minutes, membership/auxiliary, calendar/PDF) repeats the incorrect 6:00 PM time. Remaining `1800` references are for different items (SAL meeting, Riders meeting, nightly moment of silence); the `6:00 PM` in the volunteer footer relates to donation processing.
- `npm run format`, `npm run lint` (0 errors), `npm test` (83 passing), and `npm run build` (static export) all pass.

## Acceptance Criteria

- [x] Events section shows `American Legion Auxiliary Meeting: 1900 on the 4th Tuesday of the month`.
- [x] No other page repeats the incorrect 6:00 PM time.

Cross-reference: originally mis-filed as FreeForCharity/FFC-EX-legioninthewoods.org#72.