### PR TITLE
feat: add FFC-standard footer attribution and hub login link

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -73,6 +73,15 @@ describe('Footer component', () => {
     }
   })
 
+  it('should have the Free For Charity attribution and hub login link', () => {
+    render(<Footer />)
+    expect(screen.getByRole('contentinfo')).toHaveTextContent(/Supported by/i)
+    const ffcLink = screen.getByRole('link', { name: 'Free For Charity' })
+    expect(ffcLink).toHaveAttribute('href', 'https://freeforcharity.org')
+    const hubLink = screen.getByRole('link', { name: 'Supported Charity Login' })
+    expect(hubLink).toHaveAttribute('href', 'https://freeforcharity.org/hub/')
+  })
+
   it('should not have accessibility violations', async () => {
     const { container } = render(<Footer />)
     const results = await axe(container)

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -221,10 +221,30 @@ const Footer: React.FC = () => {
 
       {/* Bottom Bar */}
       <div
-        className="mt-12 py-6 px-4 border-t border-gray-800 text-center text-[18px] font-[500] w-full"
+        className="mt-12 py-6 px-4 border-t border-gray-800 text-center text-[18px] font-[500] w-full space-y-2"
         id="aria-font"
       >
         <p>© {currentYear} Nittany American Legion Post 245 | For God and Country</p>
+        <p className="text-[16px]">
+          Supported by{' '}
+          <a
+            href="https://freeforcharity.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-[#FFD700] transition-colors"
+          >
+            Free For Charity
+          </a>{' '}
+          |{' '}
+          <a
+            href="https://freeforcharity.org/hub/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-[#FFD700] transition-colors"
+          >
+            Supported Charity Login
+          </a>
+        </p>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary

Adds the FFC-standard footer elements flagged for **nittanypost245.org** in the fleet audit (ffcadmin `docs/fleet-audit-report.md`, 2026-07-12 snapshot). The audit row listed: *missing FFC link, hub link, EIN, attribution ("Supported by" / "A project of")*.

Design-matched addition to the existing black footer bottom bar, directly below the unchanged copyright line:

- **Attribution** — "Supported by [Free For Charity](https://freeforcharity.org)" (target "Supported by" wording)
- **Hub login** — "Supported Charity Login" → https://freeforcharity.org/hub/
- **Copyright** — already present and unchanged: "© {current year} Nittany American Legion Post 245 | For God and Country"

Links are white and underlined on the black footer background (WCAG AA contrast), using the site's existing gold `#FFD700` hover treatment.

### Audit checks closed

| Check | Status |
| --- | --- |
| FFC link (`freeforcharity.org` href) | ✅ added |
| Hub link (`freeforcharity.org/hub`) | ✅ added |
| Attribution — target "Supported by" wording | ✅ added |
| FFC marker ("Free For Charity" text) | already passing |
| Current-year copyright with charity name | already present |

### Intentionally omitted (legal accuracy)

- **EIN block** — no EIN for Post 245 appears on the live site, in this repo's content, or on any linked GuideStar/Candid profile (the only EIN in the repo is FFC's own 46-2471893 in template donation-policy boilerplate). Omitted rather than state an unverifiable number. **Follow-up:** obtain the post's EIN from the charity POC and add it.
- **Tax-status line** — American Legion posts are typically 501(c)(19) veterans' organizations, not 501(c)(3); no verifiable statement of Post 245's exempt status exists in site or repo content, so no status line was added. The generic "a US 501c3 Non Profit" wording would be inaccurate here.

## Test plan

- [x] `npm run format` / `npm run lint` — clean
- [x] `npm test` — all suites pass, including new Footer unit assertions for the attribution and hub-login links (jest-axe accessibility check still green)
- [x] `npm run build` — static export succeeds; attribution/hub markup verified in `out/index.html`
- [x] `npx playwright test copyright.spec.ts social-links.spec.ts` — footer e2e specs pass (copyright line unchanged)

Refs FreeForCharity/FFC-Cloudflare-Automation#697 (fleet footer retrofit — partial-class pilots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
